### PR TITLE
FIX blank tile on the website

### DIFF
--- a/_staff_members/joan.md
+++ b/_staff_members/joan.md
@@ -1,6 +1,7 @@
 ---
 name: Joan Massich
-position: Developer
-image_path: image_path: /images/joan.jpeg
-blurb: INRIA
+position: Research engineer
+website: https://massich.cat
+image_path: /images/joan.jpeg
+blurb: Research engineer at CNRS, MNE-Python core-developer.
 ---

--- a/_staff_members/sik.md
+++ b/_staff_members/sik.md
@@ -1,7 +1,0 @@
----
-name: Joan Massich
-position: Research engineer
-website: https://massich.cat
-image_path: /images/joan.jpeg
-blurb: Research engineer at CNRS, MNE-Python core-developer.
----


### PR DESCRIPTION
there is a blank tile on the website which is caused by a duplication in sik's md in the repo. before the pr, `joan.md` is blank due to missing fields and is now fixed, and the second one is now removed because it is a dupe and throws off the ordering (filename doesn't match first name). maybe we should document best practices next time lol